### PR TITLE
Switch GitHub Actions to OAuth authentication

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -35,7 +35,7 @@ jobs:
         id: claude-review
         uses: anthropics/claude-code-action@beta
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          use_oauth: true
 
           # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
           # model: "claude-opus-4-20250514"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -34,7 +34,7 @@ jobs:
         id: claude
         uses: anthropics/claude-code-action@beta
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          use_oauth: true
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |


### PR DESCRIPTION
## Summary
- Switched Claude GitHub Actions workflows from API key authentication to OAuth
- Updated both `claude.yml` and `claude-code-review.yml` to use `use_oauth: true`
- Removes the need to store `ANTHROPIC_API_KEY` in repository secrets

## Test plan
- [ ] Verify that Claude bot responds to @claude mentions in issues/PRs after merge
- [ ] Confirm automated PR reviews work without API key configuration
- [ ] Check that OAuth flow completes successfully in GitHub Actions logs

🤖 Generated with [Claude Code](https://claude.ai/code)