### PR TITLE
Update GitHub Actions workflows to use OAuth authentication

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -35,7 +35,7 @@ jobs:
         id: claude-review
         uses: anthropics/claude-code-action@beta
         with:
-          use_oauth: true
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
           # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
           # model: "claude-opus-4-20250514"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -34,7 +34,7 @@ jobs:
         id: claude
         uses: anthropics/claude-code-action@beta
         with:
-          use_oauth: true
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |


### PR DESCRIPTION
## Summary
- Updated Claude Code GitHub Actions to use OAuth authentication instead of the deprecated `use_oauth` parameter
- Fixed workflow errors by using the correct `claude_code_oauth_token` parameter

## Changes
- Replaced `use_oauth: true` with `claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}` in both workflow files:
  - `.github/workflows/claude.yml`
  - `.github/workflows/claude-code-review.yml`

## Context
The workflows were failing with the error:
> Unexpected input(s) 'use_oauth', valid inputs are ['trigger_phrase', 'assignee_trigger', ...]

This change fixes the authentication method to use the correct OAuth token parameter as documented in the [claude-code-action repository](https://github.com/anthropics/claude-code-action).

## Test plan
- [x] GitHub secret `CLAUDE_CODE_OAUTH_TOKEN` has been configured
- [ ] Workflows should run successfully after merge
- [ ] Claude bot should respond to `@claude` mentions in issues and PRs
- [ ] Automated PR reviews should work on new pull requests

🤖 Generated with [Claude Code](https://claude.ai/code)