### PR TITLE
fix(workflows): add issues write permission for sprint comments

### DIFF
--- a/.github/workflows/sprint-update.yml
+++ b/.github/workflows/sprint-update.yml
@@ -20,7 +20,7 @@ jobs:
 
     permissions:
       contents: write
-      issues: read
+      issues: write
       pull-requests: write
 
     steps:
@@ -103,6 +103,7 @@ jobs:
 
     - name: Create issue comment with report
       if: github.event_name == 'issues' && success()
+      continue-on-error: true
       uses: actions/github-script@v7
       with:
         script: |


### PR DESCRIPTION
## Summary
Fixes the sprint-update workflow permission issue that prevented issue comments from being created.

## Problem
The workflow was failing at the final step with:
```
Error: Resource not accessible by integration
HTTP 403: Resource not accessible by integration
```

## Solution
1. **Added `issues: write` permission** - Changed from `issues: read` to `issues: write`
2. **Added graceful error handling** - Added `continue-on-error: true` to comment step

## Test Plan
- [x] Modified workflow permissions
- [x] Added error handling for graceful degradation
- [ ] Test by triggering workflow on issue update

## Impact
- ✅ Sprint reports will now be posted as issue comments
- ✅ Workflow won't fail if comment creation fails
- ✅ Auto-merge system remains fully functional

Resolves the 403 permission errors in the sprint-update workflow.

🤖 Generated with [Claude Code](https://claude.ai/code)