### PR TITLE
fix(ci): ensure ISSUE parsing runs even when workflow fails

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -253,7 +253,7 @@ jobs:
 
       # ---------- Auto-open GitHub issues for Suggested Follow-ups ----------
       - name: Parse Review and Create Issues
-        if: contains(steps.claude-review.outputs.response, 'ISSUE:')
+        if: always() && contains(steps.claude-review.outputs.response, 'ISSUE:')
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |


### PR DESCRIPTION
## 🤖 ARC-Reviewer Report

![Coverage](https://img.shields.io/badge/coverage-78.5%25-yellow)

## Issue

The ARC-Reviewer workflow was not creating issues from ISSUE: lines when the overall workflow failed due to coverage regression or blocking issues. This happened because the "Parse Review and Create Issues" step only ran when the workflow was successful.

## Root Cause

In PR #62, the workflow failed due to:
- Coverage regression (78.47% < 78.5% baseline)  
- This caused the "Check for Blocking Issues" step to fail and terminate the workflow
- The "Parse Review and Create Issues" step was skipped even though Claude provided valid ISSUE: lines

## Solution

Changed the condition from:
```yaml
if: contains(steps.claude-review.outputs.response, 'ISSUE:')
```

To:
```yaml
if: always() && contains(steps.claude-review.outputs.response, 'ISSUE:')
```

This ensures that if Claude provides ISSUE: lines in their review, they will be processed and converted to GitHub issues regardless of whether the workflow passes or fails overall.

## Impact

- ✅ ISSUE: lines will now be processed even when workflows fail
- ✅ No change to successful workflow behavior
- ✅ Maintains all existing security and validation checks

## Testing

This can be tested by creating a PR that triggers a workflow failure (coverage regression or blocking issues) while having Claude provide ISSUE: suggestions in the review.

🤖 Generated with [Claude Code](https://claude.ai/code)