### PR TITLE
feat(agents): implement label batching in sprint issue linker

### DIFF
--- a/context/sprints/sprint-4.1.yaml
+++ b/context/sprints/sprint-4.1.yaml
@@ -252,6 +252,7 @@ phases:
     - scope:github-api
     dependencies: []
     estimate: 3 hours
+    github_issue: 79
 team:
 - role: lead
   agent: pm_agent

--- a/src/agents/sprint_issue_linker.py
+++ b/src/agents/sprint_issue_linker.py
@@ -523,14 +523,23 @@ _Auto-created from sprint YAML and tracked by sprint system._
 
         success = True
         try:
-            # Add new labels
-            for label in labels_to_add:
-                cmd = ["gh", "issue", "edit", str(issue_number), "--add-label", label]
+            # Batch add labels in single command
+            if labels_to_add:
+                add_labels_str = ",".join(labels_to_add)
+                cmd = ["gh", "issue", "edit", str(issue_number), "--add-label", add_labels_str]
                 subprocess.run(cmd, capture_output=True, text=True, check=True)
 
-            # Remove old labels
-            for label in labels_to_remove:
-                cmd = ["gh", "issue", "edit", str(issue_number), "--remove-label", label]
+            # Batch remove labels in single command
+            if labels_to_remove:
+                remove_labels_str = ",".join(labels_to_remove)
+                cmd = [
+                    "gh",
+                    "issue",
+                    "edit",
+                    str(issue_number),
+                    "--remove-label",
+                    remove_labels_str,
+                ]
                 subprocess.run(cmd, capture_output=True, text=True, check=True)
 
             if self.verbose and (labels_to_add or labels_to_remove):


### PR DESCRIPTION
## Summary
Fixed the sprint issue linker's `_sync_issue_labels()` method that was making individual GitHub API calls for each label operation, causing multiple comments when creating/updating issues with many labels.

## Problem Solved
The current implementation called `gh issue edit` separately for each label:
- One subprocess call per label to add (lines 527-530)
- One subprocess call per label to remove (lines 532-535)  
- With 8-12+ labels per task, this created 8-12+ GitHub API calls
- Each call could trigger comment creation, leading to comment spam

## Solution
- **Batched label additions** into single `gh issue edit --add-label label1,label2,label3` call
- **Batched label removals** into single `gh issue edit --remove-label label1,label2,label3` call  
- **Reduced API calls** from ~10+ per issue to maximum 2 per issue
- **Updated sprint-4.1.yaml** to reference GitHub issue #79

## Test Plan
- [x] All existing tests pass
- [x] Local Docker CI passes
- [x] Sprint issue linker validates correctly in dry-run mode
- [x] Label batching reduces API call count significantly

## Notes
This resolves the multiple comment issue seen in GitHub issue #70 and makes the sprint issue linker more efficient for production use.

Closes #79

🤖 Generated with [Claude Code](https://claude.ai/code)