### PR TITLE
fix(auto-merge): use GraphQL API to enable auto-merge instead of REST

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -355,12 +355,32 @@ jobs:
             const pr_number = ${{ steps.pr-parsed.outputs.pr_number }};
 
             try {
-              // Enable auto-merge with squash
-              await github.rest.pulls.enableAutoMerge({
+              // Enable auto-merge with squash using GraphQL API
+              const mutation = `
+                mutation EnableAutoMerge($pullRequestId: ID!, $mergeMethod: PullRequestMergeMethod!) {
+                  enablePullRequestAutoMerge(input: {
+                    pullRequestId: $pullRequestId
+                    mergeMethod: $mergeMethod
+                  }) {
+                    pullRequest {
+                      autoMergeRequest {
+                        enabledAt
+                      }
+                    }
+                  }
+                }
+              `;
+
+              // First get the PR node ID
+              const { data: pr } = await github.rest.pulls.get({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                pull_number: pr_number,
-                merge_method: 'squash'
+                pull_number: pr_number
+              });
+
+              const result = await github.graphql(mutation, {
+                pullRequestId: pr.node_id,
+                mergeMethod: 'SQUASH'
               });
 
               console.log('✅ Auto-merge enabled successfully');

--- a/.github/workflows/smart-auto-merge.yml
+++ b/.github/workflows/smart-auto-merge.yml
@@ -402,12 +402,32 @@ jobs:
             const prNumber = ${{ steps.check-eligibility.outputs.pr_number }};
 
             try {
-              // Enable auto-merge with squash
-              await github.rest.pulls.enableAutoMerge({
+              // Enable auto-merge with squash using GraphQL API
+              const mutation = `
+                mutation EnableAutoMerge($pullRequestId: ID!, $mergeMethod: PullRequestMergeMethod!) {
+                  enablePullRequestAutoMerge(input: {
+                    pullRequestId: $pullRequestId
+                    mergeMethod: $mergeMethod
+                  }) {
+                    pullRequest {
+                      autoMergeRequest {
+                        enabledAt
+                      }
+                    }
+                  }
+                }
+              `;
+
+              // First get the PR node ID
+              const { data: pr } = await github.rest.pulls.get({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                pull_number: prNumber,
-                merge_method: 'squash'
+                pull_number: prNumber
+              });
+
+              const result = await github.graphql(mutation, {
+                pullRequestId: pr.node_id,
+                mergeMethod: 'SQUASH'
               });
 
               console.log('✅ Auto-merge enabled successfully');


### PR DESCRIPTION
## 🤖 ARC-Reviewer Report

![Coverage](https://img.shields.io/badge/coverage-78.7%25-yellow)

## Summary

This PR fixes the auto-merge system by replacing the REST API call with the GraphQL API for enabling auto-merge.

## Problem

The auto-merge workflows were failing with:


This was causing auto-merge to fail even when all conditions were met (CI passed, ARC-Reviewer approved, PR mergeable).

## Solution

- Replace  with GraphQL  mutation
- Apply to both  and  workflows
- GraphQL API is more reliable and consistent across GitHub Actions versions

## Testing

This fix resolves the issue that prevented PR #109 from auto-merging despite all conditions being met.

## Files Changed

-  - Updated to use GraphQL API
-  - Updated to use GraphQL API

Closes #109 (retroactively - the GraphQL fix that was needed)

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>