### PR TITLE
fix(ci): move GH_TOKEN to job level for proper authentication

### DIFF
--- a/.github/workflows/pr-conflict-validator.yml
+++ b/.github/workflows/pr-conflict-validator.yml
@@ -21,6 +21,9 @@ jobs:
       pull-requests: write
       checks: write
 
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
     steps:
       - name: Checkout base branch
         uses: actions/checkout@v4
@@ -203,6 +206,3 @@ jobs:
 
             _This is an automated message from the PR Conflict Validator._`
             });
-
-env:
-  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/context/trace/scratchpad/2025-07-21-issue-1043-github-cli-auth-fix.md
+++ b/context/trace/scratchpad/2025-07-21-issue-1043-github-cli-auth-fix.md
@@ -1,0 +1,43 @@
+# Scratchpad: Issue 1043 - GitHub CLI Authentication Fix
+
+## Issue Link
+- GitHub Issue: #1043
+- Sprint: sprint-5-2
+- Task Template: context/trace/task-templates/issue-1043-fix-github-cli-authentication.md
+
+## Token Budget & Complexity
+- Estimated: 2k tokens (trivial change)
+- Complexity: Trivial - single line move in YAML file
+
+## Implementation Plan
+
+### Step 1: Create feature branch
+- Branch name: `fix/1043-github-cli-authentication`
+
+### Step 2: Make the fix
+- Remove `env:` section from workflow level (lines 207-208)
+- Add `env:` section to the `validate-conflicts` job
+- Place it after the `permissions:` section for clarity
+
+### Step 3: Verify changes
+- Ensure YAML syntax is valid
+- Confirm GH_TOKEN will be available to all steps in the job
+
+### Step 4: Test locally
+- Run yamllint on the file
+- Verify the workflow structure
+
+### Step 5: Commit and push
+- Commit message: `fix(ci): move GH_TOKEN to job level for proper authentication`
+
+### Step 6: Create PR
+- Reference issue #1043
+- Note this is part 1/3 of the larger fix
+
+## Key Details
+- Current location: Workflow level (line 207-208)
+- Target location: Inside `validate-conflicts` job, after `permissions:` block
+- Token value remains: `${{ secrets.GITHUB_TOKEN }}`
+
+## Notes
+This is a simple configuration fix that will enable GitHub CLI commands in the workflow to authenticate properly, preventing fallback to unauthenticated API calls.

--- a/context/trace/task-templates/issue-1043-fix-github-cli-authentication.md
+++ b/context/trace/task-templates/issue-1043-fix-github-cli-authentication.md
@@ -1,0 +1,97 @@
+# ────────────────────────────────────────────────────────────────────────
+# TASK: issue-1043-fix-github-cli-authentication
+# Generated from GitHub Issue #1043
+# ────────────────────────────────────────────────────────────────────────
+
+## 📌 Task Name
+`fix-issue-1043-github-cli-authentication`
+
+## 🎯 Goal (≤ 2 lines)
+> Move GH_TOKEN environment variable from workflow level to job level in pr-conflict-validator.yml to fix GitHub CLI authentication failures.
+
+## 🧠 Context
+- **GitHub Issue**: #1043 - [SPRINT-5.2] [MERGE-1/3] Fix GitHub CLI authentication in pr-conflict-validator
+- **Sprint**: sprint-5-2
+- **Phase**: Phase 2: Implementation
+- **Component**: ci
+- **Priority**: bug
+- **Why this matters**: Without proper authentication, GitHub CLI falls back to unauthenticated API calls with severe rate limits
+- **Dependencies**: Part of larger issue #1029, extracted from PR #1034
+- **Related**: PR #1034 (closed, not merged)
+
+## 🛠️ Subtasks
+
+| File | Action | Prompt Tech | Purpose | Context Impact |
+|------|--------|-------------|---------|----------------|
+| .github/workflows/pr-conflict-validator.yml | modify | Direct Edit | Move GH_TOKEN to job level | Low |
+
+## 📝 Enhanced RCICO Prompt
+**Role**
+You are a senior DevOps engineer fixing GitHub Actions workflow authentication issues.
+
+**Context**
+GitHub Issue #1043: Fix GitHub CLI authentication in pr-conflict-validator
+The workflow currently defines GH_TOKEN at the workflow level (lines 207-208), but it needs to be at the job level for GitHub CLI commands to authenticate properly.
+Current workflow uses `gh pr view` command that requires authentication.
+
+**Instructions**
+1. **Primary Objective**: Move GH_TOKEN from workflow-level env to job-level env
+2. **Scope**: Only modify the environment variable placement, no other changes
+3. **Constraints**:
+   - Maintain exact same token value: ${{ secrets.GITHUB_TOKEN }}
+   - Place in the validate-conflicts job
+   - Remove from workflow level
+4. **Prompt Technique**: Direct Edit - simple configuration change
+5. **Testing**: Verify syntax is correct and placement follows GitHub Actions best practices
+6. **Documentation**: No documentation updates needed for this change
+
+**Technical Constraints**
+• Expected diff ≤ 10 LoC, 1 file
+• Context budget: ≤ 2k tokens
+• Performance budget: No performance impact
+• Code quality: YAML syntax must be valid
+• CI compliance: Workflow must pass validation
+
+**Output Format**
+Return the modified workflow with GH_TOKEN moved to job level.
+Use conventional commits: fix(ci): move GH_TOKEN to job level for proper authentication
+
+## 🔍 Verification & Testing
+- `yamllint .github/workflows/pr-conflict-validator.yml` (YAML syntax)
+- Verify GH_TOKEN is accessible in job context
+- Ensure `gh pr view` command will authenticate properly
+- Check no other workflows are affected
+
+## ✅ Acceptance Criteria
+- [x] Move GH_TOKEN from workflow env to job env in pr-conflict-validator.yml
+- [ ] Verify GitHub CLI commands authenticate properly
+- [ ] Ensure no fallback to unauthenticated API calls
+- [ ] Test that merge_state conflict detection works correctly
+
+## 💲 Budget & Performance Tracking
+```
+Estimates based on analysis:
+├── token_budget: 2000
+├── time_budget: 15 minutes
+├── cost_estimate: $0.10
+├── complexity: trivial
+└── files_affected: 1
+
+Actuals (to be filled):
+├── tokens_used: ___
+├── time_taken: ___
+├── cost_actual: $___
+├── iterations_needed: ___
+└── context_clears: ___
+```
+
+## 🏷️ Metadata
+```yaml
+github_issue: 1043
+sprint: sprint-5-2
+phase: 2
+component: ci
+priority: bug
+complexity: trivial
+dependencies: [1029, 1034]
+```


### PR DESCRIPTION
## 🤖 ARC-Reviewer Report

![Coverage](https://img.shields.io/badge/coverage-78.5%25-yellow)

Fixes #1043

## Changes
- Moved GH_TOKEN environment variable from workflow level to job level in pr-conflict-validator.yml
- This ensures GitHub CLI commands can authenticate properly instead of falling back to unauthenticated API calls

## Testing
- [X] All CI checks pass locally
- [X] Coverage maintained at 78.0%+
- [X] Pre-commit hooks pass
- [X] YAML syntax validated

## Task Template
- Template used: context/trace/task-templates/issue-1043-fix-github-cli-authentication.md
- Estimated budget: 2k tokens / 15 minutes
- Actual usage: ~3k tokens / 10 minutes

## Verification
- [X] Docker CI passed locally
- [X] All tests pass
- [X] Context validation successful

## Context Changes
- Added task template and scratchpad documentation for this issue

## Sprint Impact
- Sprint: sprint-5-2
- Phase: Phase 2: Implementation
- Component: ci

This is part 1/3 of the fixes extracted from PR #1034 to resolve the false positive branch behind warnings in issue #1029.