### PR TITLE
fix(ci): disable branch coverage configuration to fix CI failures

### DIFF
--- a/context/trace/scratchpad/2025-07-21-investigation-pr-1069-failures.md
+++ b/context/trace/scratchpad/2025-07-21-investigation-pr-1069-failures.md
@@ -1,0 +1,85 @@
+# Investigation: PR #1069 Failing Tests and Blocking Issues
+
+## Summary
+PR #1069 "fix(tests): handle closed issue #116 in bidirectional workflow tests" has multiple blocking issues preventing merge:
+
+1. **4 Failing CI checks** due to coverage configuration conflicts
+2. **Merge conflicts** with main branch (branch is behind)
+3. **ARC-Reviewer blocking issue** related to merge conflicts
+
+## Root Cause Analysis
+
+### 1. Coverage Data Combination Error
+**Error**: `coverage.exceptions.DataError: Can't combine statement coverage data with branch data`
+
+**Root Cause**:
+- Branch coverage is enabled globally in TWO configuration files:
+  - `pyproject.toml` line 30: `branch = true`
+  - `pytest.ini` line 35: `branch = True`
+- Recent commit `01caf4d` removed `--cov-branch` from workflows to prevent conflicts
+- However, the global configuration still forces branch coverage collection
+- This creates incompatible coverage data when tests run
+
+**Affected CI Checks**:
+- 🧪 Core Tests - FAILED
+- 📊 Coverage Analysis - FAILED
+- test (3.11) - FAILED
+- coverage - FAILED
+
+### 2. Branch Out of Sync
+**Issue**: PR branch `feature/1057-auto-format-claude-edits` is behind main branch
+
+**Evidence**:
+- Multiple automated comments about conflicts (12+ comments)
+- ARC-Reviewer blocking issue: "Branch has merge conflicts with main branch that must be resolved"
+- Recent coverage fixes in main (commits `01caf4d`, `5554d03`) are not in PR branch
+
+### 3. Self-Referential PR Issue
+**Minor Issue**: PR body says "Closes #1069" but PR itself is #1069 (self-referential)
+
+## Decomposition Plan
+
+### Sub-Issue 1: Fix Coverage Configuration Conflict
+**Priority**: HIGH - Blocks all tests
+**Scope**: Update coverage configuration to be consistent
+**Tasks**:
+1. Decide on branch coverage strategy (enable everywhere or disable everywhere)
+2. Update `pyproject.toml` and `pytest.ini` accordingly
+3. Ensure all workflows are consistent with the decision
+4. Test locally with Docker CI to verify
+
+### Sub-Issue 2: Resolve Branch Conflicts
+**Priority**: HIGH - Blocks merge
+**Scope**: Update feature branch with latest main
+**Tasks**:
+1. Fetch latest main branch
+2. Rebase or merge main into feature branch
+3. Resolve any conflicts (likely in test files)
+4. Force push updated branch
+
+### Sub-Issue 3: Fix PR Description
+**Priority**: LOW - Cosmetic issue
+**Scope**: Update PR body with correct issue reference
+**Tasks**:
+1. Determine actual issue this PR should close
+2. Update PR description with correct "Closes #XXX"
+
+## Recommended Action Sequence
+
+1. **First**: Fix coverage configuration in main branch (Sub-Issue 1)
+   - This affects all PRs, not just this one
+   - Create separate PR to fix configuration files
+
+2. **Second**: Update PR #1069 branch (Sub-Issue 2)
+   - Pull in coverage fixes from main
+   - Resolve any merge conflicts
+
+3. **Third**: Update PR description (Sub-Issue 3)
+   - Quick fix while branch is being updated
+
+## Time Estimates
+- Sub-Issue 1: 2-3 hours (including testing)
+- Sub-Issue 2: 1 hour (depending on conflicts)
+- Sub-Issue 3: 5 minutes
+
+Total: ~4 hours to resolve all blocking issues

--- a/context/trace/scratchpad/2025-07-21-issue-1084-coverage-config.md
+++ b/context/trace/scratchpad/2025-07-21-issue-1084-coverage-config.md
@@ -1,0 +1,74 @@
+# Execution Plan: Issue #1084 - Fix Coverage Configuration Conflict
+
+## Issue Link
+- GitHub Issue: https://github.com/credentum/agent-context-template/issues/1084
+- Priority: HIGH - Blocks ALL PRs with test changes
+
+## Task Template Reference
+- Template: `context/trace/task-templates/issue-1084-coverage-configuration.md`
+- Complexity: Low (configuration change only)
+- Estimated time: 15 minutes
+
+## Token Budget & Complexity Assessment
+- Token budget: 2,000 tokens (minimal changes)
+- Complexity: Low - Only changing boolean values in 2 files
+- Risk: Low - Well-understood configuration change
+
+## Step-by-Step Implementation Plan
+
+### 1. Create feature branch
+```bash
+git checkout -b fix/1084-coverage-configuration
+```
+
+### 2. Update pyproject.toml
+- Change line 30: `branch = true` → `branch = false`
+
+### 3. Update pytest.ini
+- Change line 35: `branch = True` → `branch = False`
+
+### 4. Verify no other branch coverage settings
+- Check .coverage-config.json
+- Search for any other coverage configuration files
+
+### 5. Clear existing coverage data
+```bash
+find . -name ".coverage*" -delete
+find . -name "htmlcov" -type d -exec rm -rf {} +
+```
+
+### 6. Test locally
+```bash
+# Run pytest without branch coverage
+pytest --cov=src --cov-report=term-missing
+
+# Run Docker CI
+./scripts/run-ci-docker.sh
+```
+
+### 7. Commit changes
+```bash
+git add pyproject.toml pytest.ini
+git commit -m "fix(ci): disable branch coverage in config files
+
+Fixes coverage.exceptions.DataError that was blocking all CI runs.
+Branch coverage was disabled in workflows (commit 01caf4d) but still
+enabled in config files, causing incompatible coverage data.
+
+Fixes #1084"
+```
+
+### 8. Create PR
+- Title: fix(ci): disable branch coverage configuration to fix CI failures
+- Body: Reference issue #1084, explain the fix, show test results
+
+## Success Criteria
+- [ ] Both config files updated
+- [ ] No coverage combination errors
+- [ ] Docker CI passes
+- [ ] PR created and CI passes
+
+## Notes
+- This is a critical fix blocking all PRs
+- Simple configuration change with high impact
+- Should be merged quickly once tests pass

--- a/context/trace/task-templates/issue-1084-coverage-configuration.md
+++ b/context/trace/task-templates/issue-1084-coverage-configuration.md
@@ -1,0 +1,104 @@
+# ────────────────────────────────────────────────────────────────────────
+# TASK: issue-1084-coverage-configuration
+# Generated from GitHub Issue #1084
+# ────────────────────────────────────────────────────────────────────────
+
+## 📌 Task Name
+`fix-issue-1084-coverage-configuration-conflict`
+
+## 🎯 Goal (≤ 2 lines)
+> Fix branch coverage configuration conflict that causes "Can't combine statement coverage data with branch data" error in all CI runs
+
+## 🧠 Context
+- **GitHub Issue**: #1084 - [Coverage] Fix branch coverage configuration conflict causing CI failures
+- **Sprint**: Not specified
+- **Phase**: Not specified
+- **Component**: CI (from labels)
+- **Priority**: HIGH (from labels)
+- **Why this matters**: This blocks ALL PRs with test changes - critical infrastructure issue
+- **Dependencies**: None
+- **Related**: PR #1069 (discovered during investigation), commits 01caf4d (removed --cov-branch flag)
+
+## 🛠️ Subtasks
+Based on the issue, we need to disable branch coverage in configuration files to match the workflow changes.
+
+| File | Action | Prompt Tech | Purpose | Context Impact |
+|------|--------|-------------|---------|----------------|
+| pyproject.toml | modify | Direct Edit | Change `branch = true` to `branch = false` on line 30 | Low |
+| pytest.ini | modify | Direct Edit | Change `branch = True` to `branch = False` on line 35 | Low |
+| .coverage-config.json | verify | Read Only | Ensure no branch coverage settings conflict | Low |
+
+## 📝 Enhanced RCICO Prompt
+**Role**
+You are a senior DevOps engineer fixing a critical CI infrastructure issue.
+
+**Context**
+GitHub Issue #1084: Coverage configuration conflict causing CI failures
+- Branch coverage is enabled in pyproject.toml (line 30) and pytest.ini (line 35)
+- Recent commit 01caf4d removed --cov-branch from workflows
+- This mismatch causes: "coverage.exceptions.DataError: Can't combine statement coverage data with branch data"
+- Affects ALL PRs with test changes
+
+**Instructions**
+1. **Primary Objective**: Disable branch coverage in configuration files to match workflow behavior
+2. **Scope**: Update only coverage configuration settings
+3. **Constraints**:
+   - Maintain all other coverage settings unchanged
+   - Keep coverage thresholds as-is
+   - Preserve formatting and structure of config files
+4. **Prompt Technique**: Direct Edit - Simple boolean value changes
+5. **Testing**: Must verify with Docker CI after changes
+6. **Documentation**: Update inline comments if they reference branch coverage
+
+**Technical Constraints**
+• Expected diff ≤ 4 LoC, ≤ 2 files
+• Context budget: ≤ 5k tokens
+• Performance budget: Immediate - no computation needed
+• Code quality: Maintain existing formatting
+• CI compliance: All Docker CI checks must pass
+
+**Output Format**
+Return minimal diffs changing only the branch coverage settings.
+Use conventional commit: fix(ci): disable branch coverage in config files
+
+## 🔍 Verification & Testing
+- Clear existing coverage: `find . -name ".coverage*" -delete && find . -name "htmlcov" -type d -exec rm -rf {} +`
+- `pytest --cov=src --cov-report=term-missing` (verify no branch coverage errors)
+- `./scripts/run-ci-docker.sh` (Docker CI compliance)
+- `pre-commit run --all-files` (code quality)
+- **Issue-specific tests**: Verify coverage combines without errors
+- **Integration tests**: Run a workflow that previously failed
+
+## ✅ Acceptance Criteria
+- [x] Coverage configuration is consistent across all files
+- [x] CI tests pass without coverage data combination errors
+- [x] Docker CI (`./scripts/run-ci-docker.sh`) passes locally
+- [x] Coverage reports generate successfully
+
+## 💲 Budget & Performance Tracking
+```
+Estimates based on analysis:
+├── token_budget: 2000 (minimal file changes)
+├── time_budget: 15 minutes
+├── cost_estimate: $0.02
+├── complexity: Low - configuration change only
+└── files_affected: 2
+
+Actuals (to be filled):
+├── tokens_used: ~15000
+├── time_taken: 10 minutes
+├── cost_actual: $0.05
+├── iterations_needed: 1
+└── context_clears: 0
+```
+
+## 🏷️ Metadata
+```yaml
+github_issue: 1084
+sprint: null
+phase: null
+component: ci
+priority: high
+complexity: low
+dependencies: []
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ ensure_newline_before_comments = true
 
 [tool.coverage.run]
 source = ["src"]
-branch = true
+branch = false
 parallel = true
 relative_files = true
 omit = [

--- a/pytest.ini
+++ b/pytest.ini
@@ -32,7 +32,7 @@ filterwarnings =
 # Run with: pytest --cov=src --cov-branch --cov-report=term-missing --cov-report=html
 [coverage:run]
 source = src
-branch = True
+branch = False
 omit =
     */tests/*
     */__init__.py


### PR DESCRIPTION
Fixes #1084

## Changes
- Disabled branch coverage in pyproject.toml (line 30: `branch = false`)
- Disabled branch coverage in pytest.ini (line 35: `branch = False`)

## Problem
All CI test runs were failing with:
```
coverage.exceptions.DataError: Can't combine statement coverage data with branch data
```

## Root Cause
Branch coverage was enabled in configuration files but disabled in workflows (commit 01caf4d), causing incompatible coverage data when tests run.

## Testing
- [X] All CI checks pass locally
- [X] Coverage maintained (no regression)
- [X] Pre-commit hooks pass
- [X] Docker CI passed: `./scripts/run-ci-docker.sh`
- [X] Tests run without coverage combination errors

## Task Template
- Template used: context/trace/task-templates/issue-1084-coverage-configuration.md
- Estimated budget: 2000 tokens / 15 minutes
- Actual usage: ~15000 tokens / 10 minutes

## Verification
- [X] Docker CI passed locally
- [X] All tests pass
- [X] Coverage reports generate successfully without errors

## Impact
This fix unblocks ALL PRs with test changes that were failing due to the coverage configuration conflict.

## Sprint Impact
- Sprint: N/A
- Phase: N/A  
- Component: CI