### PR TITLE
fix(ci): use .flake8 config instead of inline parameters

### DIFF
--- a/context/trace/scratchpad/2025-07-22-issue-1201-fix-flake8-errors.md
+++ b/context/trace/scratchpad/2025-07-22-issue-1201-fix-flake8-errors.md
@@ -1,0 +1,40 @@
+# Issue #1201 Execution Plan - Fix flake8 errors blocking pre-push hooks
+
+**Issue Link**: https://github.com/droter/agent-context-template/issues/1201
+**Sprint**: sprint-4-2
+**Task Template**: context/trace/task-templates/issue-1201-fix-flake8-errors-blocking-pre-push-hooks.md
+
+## Problem Analysis
+- `tests/test_formatting_issues.py` is intentionally broken for testing formatters
+- `.flake8` config excludes this file on line 21
+- Pre-commit hooks work correctly (respect .flake8 config)
+- Docker CI uses inline flake8 parameters, ignoring .flake8 exclude settings
+- This causes CI failures that force developers to use SKIP_HOOKS=1
+
+## Root Cause
+Two locations use inline flake8 parameters instead of .flake8 config:
+1. `scripts/test-comprehensive-ci.sh:54` - inline parameters
+2. `docker-compose.ci.yml:89-91` - inline parameters
+
+## Solution Strategy
+Replace inline flake8 parameters with simple `flake8` command to use .flake8 config file.
+
+## Token Budget & Complexity
+- **Estimated tokens**: 5,000 (simple config fix)
+- **Estimated time**: 15 minutes
+- **Files to modify**: 2
+- **Complexity**: Low (configuration change only)
+
+## Implementation Steps
+1. Create feature branch
+2. Modify scripts/test-comprehensive-ci.sh line 54 to use `flake8` without inline params
+3. Modify docker-compose.ci.yml lines 89-91 to use `flake8` without inline params
+4. Ensure .flake8 config file is mounted in Docker containers
+5. Test with Docker CI
+6. Verify tests/test_formatting_issues.py is properly excluded
+
+## Verification Plan
+- Run `./scripts/run-ci-docker.sh` - must pass
+- Run `./scripts/run-ci-docker.sh flake8` - must pass
+- Verify no flake8 errors on test_formatting_issues.py
+- Verify other files still get checked by flake8

--- a/context/trace/task-templates/issue-1201-fix-flake8-errors-blocking-pre-push-hooks.md
+++ b/context/trace/task-templates/issue-1201-fix-flake8-errors-blocking-pre-push-hooks.md
@@ -1,0 +1,106 @@
+# ────────────────────────────────────────────────────────────────────────
+# TASK: issue-1201-fix-flake8-errors-blocking-pre-push-hooks
+# Generated from GitHub Issue #1201
+# ────────────────────────────────────────────────────────────────────────
+
+## 📌 Task Name
+`fix-issue-1201-fix-flake8-errors-blocking-pre-push-hooks`
+
+## 🎯 Goal (≤ 2 lines)
+> Fix Docker CI configuration to respect .flake8 exclude settings, preventing test_formatting_issues.py from blocking pre-push hooks
+
+## 🧠 Context
+- **GitHub Issue**: #1201 - [SPRINT-4.2] Fix flake8 errors blocking pre-push hooks
+- **Sprint**: sprint-4-2
+- **Phase**: Phase 2: Implementation
+- **Component**: testing
+- **Priority**: high (blocking pre-push hooks)
+- **Why this matters**: Developers cannot push code without SKIP_HOOKS=1, bypassing quality checks
+- **Dependencies**: None - configuration fix only
+- **Related**: Pre-commit hooks work correctly, Docker CI does not
+
+## 🛠️ Subtasks
+
+| File | Action | Prompt Tech | Purpose | Context Impact |
+|------|--------|-------------|---------|----------------|
+| scripts/test-comprehensive-ci.sh | modify | Direct fix | Use .flake8 config instead of inline params | Low |
+| docker-compose.ci.yml | modify | Direct fix | Mount .flake8 config file | Low |
+
+## 📝 Enhanced RCICO Prompt
+**Role**
+You are a senior DevOps engineer working on CI/CD pipeline configuration.
+
+**Context**
+GitHub Issue #1201: Fix flake8 errors blocking pre-push hooks
+The tests/test_formatting_issues.py file is intentionally designed with formatting issues for testing formatters. It has proper exclusion in .flake8 config file but Docker CI environment ignores this configuration and uses inline parameters instead. Pre-commit hooks work correctly because they respect .flake8 config.
+
+Current problem: Docker CI runs `flake8 src/ tests/ scripts/ --max-line-length=100 --extend-ignore=E203,W503` instead of using the .flake8 config file that excludes tests/test_formatting_issues.py.
+
+Related files:
+- .flake8 (has proper exclude on line 21)
+- scripts/test-comprehensive-ci.sh (line 54 - uses inline params)
+- docker-compose.ci.yml (lines 89-91 - uses inline params)
+
+**Instructions**
+1. **Primary Objective**: Make Docker CI respect .flake8 configuration file exclude settings
+2. **Scope**: Fix CI configuration without modifying the intentionally broken test file
+3. **Constraints**:
+   - Do NOT modify tests/test_formatting_issues.py (it's intentionally broken for testing)
+   - Maintain all existing flake8 settings (max-line-length=100, extend-ignore=E203,W503)
+   - Keep the same behavior for all other files
+4. **Prompt Technique**: Direct configuration fix because this is a straightforward config issue
+5. **Testing**: Verify Docker CI no longer fails on test_formatting_issues.py
+6. **Documentation**: Update if needed to clarify CI behavior
+
+**Technical Constraints**
+• Expected diff ≤ 10 LoC, ≤ 2 files
+• Context budget: ≤ 5k tokens
+• Performance budget: Configuration change only
+• Code quality: Must maintain existing CI behavior for all other files
+• CI compliance: Docker CI must pass after changes
+
+**Output Format**
+Return complete implementation addressing CI configuration issue.
+Use conventional commits: fix(ci): use .flake8 config instead of inline parameters
+
+## 🔍 Verification & Testing
+- `./scripts/run-ci-docker.sh` (Docker CI compliance - must pass)
+- `pre-commit run flake8 --all-files` (verify pre-commit still works)
+- Verify tests/test_formatting_issues.py is properly excluded from CI
+- Verify other files still get proper flake8 checking
+
+## ✅ Acceptance Criteria
+- [ ] All flake8 errors in Docker CI environment are resolved
+- [ ] Pre-push hooks execute successfully without requiring SKIP_HOOKS=1
+- [ ] No regressions in existing functionality (other files still checked)
+- [ ] Code follows project formatting standards
+- [ ] tests/test_formatting_issues.py remains excluded from flake8 checks
+- [ ] Docker CI respects .flake8 configuration file
+
+## 💲 Budget & Performance Tracking
+```
+Estimates based on analysis:
+├── token_budget: 5000 (simple config fix)
+├── time_budget: 15 minutes (straightforward change)
+├── cost_estimate: $0.05
+├── complexity: Low (configuration change only)
+└── files_affected: 2
+
+Actuals (to be filled):
+├── tokens_used: ___
+├── time_taken: ___
+├── cost_actual: $___
+├── iterations_needed: ___
+└── context_clears: ___
+```
+
+## 🏷️ Metadata
+```yaml
+github_issue: 1201
+sprint: sprint-4-2
+phase: "Phase 2: Implementation"
+component: testing
+priority: high
+complexity: low
+dependencies: []
+```

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -28,6 +28,7 @@ services:
       - ./pyproject.toml:/app/pyproject.toml:ro
       - ./.pre-commit-config.yaml:/app/.pre-commit-config.yaml:ro
       - ./.yamllint-workflows.yml:/app/.yamllint-workflows.yml:ro
+      - ./.flake8:/app/.flake8:ro
     environment:
       - PYTHONPATH=/app
       - CI=true
@@ -80,15 +81,14 @@ services:
       - ./src:/app/src:ro
       - ./tests:/app/tests:ro
       - ./scripts:/app/scripts:ro
+      - ./.flake8:/app/.flake8:ro
     environment:
       - CI=true
       - PYTHONUNBUFFERED=1
       - PYTHONPATH=/app
       - CACHE_VERSION=v2025-07-16
       - PYTHON_VERSION=3.11
-    command: >
-      flake8 src/ tests/ scripts/ --max-line-length=100
-      --extend-ignore=E203,W503
+    command: flake8 src/ tests/ scripts/
 
   ci-mypy:
     build:
@@ -277,6 +277,7 @@ services:
       - ./mypy.ini:/app/mypy.ini:ro
       - ./pyproject.toml:/app/pyproject.toml:ro
       - ./.pre-commit-config.yaml:/app/.pre-commit-config.yaml:ro
+      - ./.flake8:/app/.flake8:ro
     environment:
       - PYTHONPATH=/app
       - CI=true
@@ -290,9 +291,7 @@ services:
         (echo '  ▶ Black...' && black --check src/ tests/ scripts/) &
         (echo '  ▶ isort...' && \
           isort --check-only --profile black src/ tests/ scripts/) &
-        (echo '  ▶ Flake8...' && \
-          flake8 src/ tests/ scripts/ \
-          --max-line-length=100 --extend-ignore=E203,W503) &
+        (echo '  ▶ Flake8...' && flake8 src/ tests/ scripts/) &
         (echo '  ▶ MyPy...' && mypy src/ --config-file=mypy.ini) &
         (echo '  ▶ Context lint...' && \
           python -m src.agents.context_lint validate context/) &

--- a/scripts/test-comprehensive-ci.sh
+++ b/scripts/test-comprehensive-ci.sh
@@ -51,7 +51,7 @@ echo "=================================="
 
 run_check "Black formatting" "black --check src/ tests/ scripts/"
 run_check "isort import sorting" "isort --check-only --profile black src/ tests/ scripts/"
-run_check "Flake8 linting" "flake8 src/ tests/ scripts/ --max-line-length=100 --extend-ignore=E203,W503"
+run_check "Flake8 linting" "flake8 src/ tests/ scripts/"
 run_check "MyPy type checking (src/)" "mypy src/ --config-file=mypy.ini"
 run_check "MyPy type checking (tests/)" "mypy tests/ --config-file=mypy.ini" "true"
 run_check "Context YAML validation" "python -m src.agents.context_lint validate context/"


### PR DESCRIPTION
Fixes #1201

## Changes
- Remove inline flake8 parameters from CI scripts to use .flake8 config file
- Mount .flake8 config file in Docker containers for proper exclude behavior
- Ensure tests/test_formatting_issues.py is properly excluded from flake8 checks

## Problem Solved
tests/test_formatting_issues.py is intentionally broken for testing formatters but Docker CI was using inline flake8 parameters instead of .flake8 config, causing pre-push hook failures.

## Solution
Modified CI configuration to respect .flake8 exclude settings.

## Testing
- [X] Docker CI flake8 checks pass
- [X] Pre-commit hooks work correctly  
- [X] Other files still get proper flake8 checking