### PR TITLE
feat(commands): add /close-pr command for PR cleanup workflow

### DIFF
--- a/.claude/commands/close-pr.md
+++ b/.claude/commands/close-pr.md
@@ -1,0 +1,54 @@
+# Close PR Command
+
+Cleanup workflow after PR work: clears context, switches to main, pulls latest, cleans up local branches, and exits.
+
+## Usage
+
+```bash
+/close-pr
+```
+
+## Implementation
+
+This command executes a series of cleanup operations:
+
+1. Clear the current context using `/clear`
+2. Switch to the main branch
+3. Pull latest changes from remote main
+4. Clean up local branches (remove merged branches)
+5. Exit the Claude session
+
+## What It Does
+
+Performs a complete cleanup workflow to reset your environment after PR work:
+
+```bash
+# 1. Clear context
+/clear
+
+# 2. Switch to main branch
+git checkout main
+
+# 3. Pull latest changes
+git pull origin main
+
+# 4. Clean up merged branches
+git branch --merged | grep -v "\*\|main" | xargs -n 1 git branch -d
+
+# 5. Exit session
+exit
+```
+
+## Example
+
+```bash
+# After finishing PR work
+/close-pr
+```
+
+## Notes
+
+- Ensures you're back on an updated main branch
+- Removes only merged branches (safe cleanup)
+- Clears Claude context to start fresh next time
+- Automatically exits after cleanup

--- a/.claude/guides/cli-reference.md
+++ b/.claude/guides/cli-reference.md
@@ -7,6 +7,7 @@
 - `claude -c` or `--continue` - Reopen last session
 - `/clear` - Wipe context; use between tasks
 - `/compact` - Summarize conversation to free tokens
+- `/close-pr` - Cleanup after PR work (clear, switch to main, pull, clean branches, exit)
 
 ### Code Operations
 - `/review` - AI code review current diff or PR
@@ -59,3 +60,4 @@ claude
 - Use `/clear` between distinct threads to avoid context bleed
 - Keep prompts concise; prefer bullet lists to prose
 - For complex tasks, break into smaller sub-tasks
+- Use `/close-pr` after finishing PR work to cleanup and reset

--- a/context/trace/scratchpad/2025-07-31-issue-1681-[sprint-4.3]-fix-workflow-branch-name-generation-i.md
+++ b/context/trace/scratchpad/2025-07-31-issue-1681-[sprint-4.3]-fix-workflow-branch-name-generation-i.md
@@ -1,0 +1,13 @@
+# Scratchpad: Issue #1681 - [SPRINT-4.3] Fix workflow branch name generation in workflow executor
+
+## Execution Plan
+- Phase 0: Investigation (if needed)
+- Phase 1: Planning (current)
+- Phase 2: Implementation
+- Phase 3: Testing & Validation
+- Phase 4: PR Creation
+- Phase 5: Monitoring
+
+## Notes
+- Created: 2025-07-31T15:58:45.289008
+- Issue: #1681

--- a/context/trace/task-templates/issue-1681-[sprint-4.3]-fix-workflow-branch-name-generation-i.md
+++ b/context/trace/task-templates/issue-1681-[sprint-4.3]-fix-workflow-branch-name-generation-i.md
@@ -1,0 +1,105 @@
+# ────────────────────────────────────────────────────────────────────────
+# TASK: issue-1681-[sprint-4.3]-fix-workflow-branch-name-generation-i
+# Generated from GitHub Issue #1681
+# ────────────────────────────────────────────────────────────────────────
+
+## 📌 Task Name
+`fix-issue-1681-[sprint-4.3]-fix-workflow-branch-name-generation-i`
+
+## 🎯 Goal (≤ 2 lines)
+> [SPRINT-4.3] Fix workflow branch name generation in workflow executor
+
+## 🧠 Context
+- **GitHub Issue**: #1681 - [SPRINT-4.3] Fix workflow branch name generation in workflow executor
+- **Labels**: bug, sprint-current, claude-ready
+- **Component**: workflow-automation
+- **Why this matters**: Resolves reported issue
+
+## 🛠️ Subtasks
+| File | Action | Prompt Tech | Purpose | Context Impact |
+|------|--------|-------------|---------|----------------|
+| TBD | TBD | TBD | TBD | TBD |
+
+## 📝 Issue Description
+## Task Context
+**Sprint**: sprint-4.3
+**Phase**: Phase 3: Testing & Refinement
+**Component**: workflow-automation
+
+## Scope Assessment
+- [x] **Scope is clear** - Requirements are well-defined, proceed with implementation
+- [ ] **Scope needs investigation** - Create investigation issue first (use investigation.md template)
+- [ ] **Partially clear** - Some aspects need investigation (note below)
+
+**Investigation Notes**: Root cause has been identified through code analysis
+
+## Acceptance Criteria
+- [ ] Workflow executor generates meaningful branch names based on issue title
+- [ ] Branch type (fix/feature/chore) is determined from issue labels or title
+- [ ] Implementation phase reuses title_slug logic from planning phase
+- [ ] Clear error messages guide users when on main branch
+- [ ] Resume capability works after manual branch creation
+
+## Claude Code Readiness Checklist
+- [x] **Context URLs identified** (docs, specs, related PRs)
+- [x] **File scope estimated** (< 4 files, < 400 LoC expected)
+- [x] **Dependencies mapped** (external APIs, config, other services)
+- [x] **Test strategy defined** (unit, integration, edge cases)
+- [x] **Breaking change assessment** (backward compatibility)
+
+## Pre-Execution Context
+**Key Files**: 
+- `scripts/workflow_executor.py` (line 296 - hardcoded branch name)
+- `scripts/workflow_cli.py` (workflow state management)
+- `scripts/hybrid_workflow_executor.py` (if using same pattern)
+
+**External Dependencies**: 
+- GitHub CLI (gh) for issue data fetching
+- Git for branch operations
+
+**Configuration**: None required
+
+**Related Issues/PRs**: 
+- #1677 (Issue where workflow broke due to branch naming)
+- This was discovered while implementing two-phase CI architecture
+
+## Implementation Notes
+### Root Cause
+The workflow executor hardcodes branch names as `fix/{issue_number}-workflow-persistence` instead of generating meaningful names from issue titles. This causes:
+1. Uninformative branch names
+2. Always uses 'fix/' prefix regardless of issue type
+3. Inconsistency with planning phase which properly generates title_slug
+
+### Solution Approach
+1. **Extract common issue fetching**: Create shared method to get issue details
+2. **Generate proper branch names**: 
+   - Use title_slug generation (same as planning phase)
+   - Determine prefix from labels (bug→fix, enhancement→feature, etc.)
+   - Handle special characters and length limits
+3. **Improve error messages**: When on main branch, show what branch will be created
+4. **Add resume awareness**: Guide users on manual branch creation + --resume option
+
+### Code Locations
+- Line 296 in workflow_executor.py: `branch_name = f"fix/{self.issue_number}-workflow-persistence"`
+- Line 195 in workflow_executor.py: Has proper title_slug generation logic
+- Line 138-142 in workflow_cli.py: State reset logic
+
+---
+
+## Claude Code Execution
+**Session Started**: <\!-- timestamp -->
+**Task Template Created**: <\!-- link to generated template -->
+**Token Budget**: ~8000 tokens
+**Completion Target**: 30-45 minutes
+
+_This issue will be updated during Claude Code execution with progress and results._
+
+## 🔍 Verification & Testing
+- Run CI checks locally
+- Test the specific functionality
+- Verify issue is resolved
+
+## ✅ Acceptance Criteria
+- Issue requirements are met
+- Tests pass
+- No regressions introduced


### PR DESCRIPTION
## Summary
- Add new `/close-pr` command to streamline post-PR cleanup workflow
- Update CLI reference guide to document the new command
- Provides one-command cleanup: clear context, switch to main, pull latest, clean branches, exit

## Test plan
- [ ] Verify `/close-pr` command documentation is properly formatted in `.claude/commands/close-pr.md`
- [ ] Confirm CLI reference guide includes the new command in both command list and best practices
- [ ] Test command execution flow matches documented behavior

🤖 Generated with [Claude Code](https://claude.ai/code)