### PR TITLE
fix(agents): add missing YAML frontmatter to architecture-review agent

### DIFF
--- a/.claude/agents/architecture-review.md
+++ b/.claude/agents/architecture-review.md
@@ -1,3 +1,9 @@
+---
+name: architecture-review
+description: Performs comprehensive architectural analysis of the repository and creates GitHub issues using gh CLI to track technical debt and architectural improvements.
+tools: read_file,search_files,run_cmd,create_file,edit_file
+---
+
 # Architecture Review and Issue Creation
 
 Performs comprehensive architectural analysis of the repository and creates GitHub issues using gh CLI.


### PR DESCRIPTION
## Summary
- Added required YAML frontmatter to architecture-review.md agent file
- Fixed issue where the agent wasn't appearing in the `/agents` command
- Included proper name, description, and tools metadata

## Problem
The architecture-review.md agent file was missing the required YAML frontmatter that Claude Code uses to identify and list agent files. This caused it to not appear when running the `/agents` command.

## Solution
Added the standard YAML frontmatter block with:
- `name: architecture-review`
- `description:` comprehensive description of the agent's functionality
- `tools:` list of required tools (read_file, search_files, run_cmd, create_file, edit_file)

## Test plan
- [x] Verify the agent now appears in `/agents` command output
- [x] Confirm YAML frontmatter follows the same format as other agent files
- [x] Ensure no functionality was changed, only metadata added

🤖 Generated with [Claude Code](https://claude.ai/code)